### PR TITLE
no need for concurrent futures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 .idea
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='lambda-warmer-py',
-    version='1.0.alpha',
+    version='0.2.0',
     author='Rob Howley',
     author_email='howley.robert@gmail.com',
     description='keep lambdas warm and monitor cold starts with a simple decorator',
@@ -18,9 +18,5 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-    ],
-
-    install_requires={
-        "futures ; python_version == '2.7'"
-    }
+    ]
 )

--- a/tests/test_warmer.py
+++ b/tests/test_warmer.py
@@ -29,9 +29,9 @@ class TestWarmerFanOut(unittest.TestCase):
 
         self.warmer_invocation_event = dict(warmer=True, concurrency=3)
 
-        self.to_invoke_call = lambda inv_num: {
+        self.to_invoke_call = lambda inv_num, inv_type='Event': {
             'function_name': 'FAILED_TO_RETRIEVE_LAMBDA_NAME',
-            'invoke_type': 'RequestResponse',
+            'invoke_type': inv_type,
             'payload': {
                 '__WARMER_CORRELATION_ID__': '123',
                 'warmer': True,
@@ -76,7 +76,7 @@ class TestWarmerFanOut(unittest.TestCase):
 
         self.assertListEqual(
             self.lambda_client.calls,
-            [self.to_invoke_call(2), self.to_invoke_call(3)]
+            [self.to_invoke_call(2), self.to_invoke_call(3, inv_type='RequestResponse')]
         )
 
     def test_if_not_warmer_do_not_bother(self):


### PR DESCRIPTION
lambda invoke in boto is already fire and forget w `'Event'`
just wait on last one to avoid reuse of caller container